### PR TITLE
Add codex-profiles to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ List of AI-powered command-line tools. See [feature matrix](./FEATURE_MATRIX.md#
 
 ## Resources
 
+- [codex-profiles](https://github.com/Ducksss/codex-profiles) - Bash helper for switching OpenAI Codex CLI/Desktop accounts with isolated `CODEX_HOME` profiles, without copying tokens.
 - <https://github.com/inmve/free-ai-coding>
 
 ---


### PR DESCRIPTION
## Summary

Adds `codex-profiles`, a small open-source helper for switching Codex CLI and Codex Desktop accounts with isolated `CODEX_HOME` profiles.

## Why

The repo tracks AI coding tools and already lists Codex in its CLI section. codex-profiles is a companion resource for Codex users who need isolated CLI/Desktop account state without copying auth files.

## Validation

- Ran `git diff --check`

