### PR TITLE
Add BuilderStudio to AI coding tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,20 +70,20 @@ See [AI providers](https://github.com/dalisoft/awesome-hosting#llminference-api)
 
 List of AI-powered IDEs and code editors.
 
-| Name                                     | Minimal plan                                    | Usage        | Trial  | Free plan | Open Source |
-| ---------------------------------------- | ----------------------------------------------- | ------------ | ------ | --------- | ----------- |
-| [FlexPilot AI](https://flexpilot.ai)     | BYOK                                            | Tokens       | -      | -         | Yes         |
-| [VoidEditor](https://voideditor.com)     | BYOK                                            | Tokens       | -      | -         | Yes         |
-| [humanlayer](https://www.humanlayer.dev) | BYOK                                            | Tokens       | -      | -         | Yes         |
-| [Trae AI](https://trae.ai)               | [Pro](https://www.trae.ai/pricing) (10 \$/m)    | Subscription | 3 \$/m | Yes       | No          |
-| [Zed](https://zed.dev)                   | [Pro](https://zed.dev/pricing) (10 \$/m)        | Tokens       | 2-week | Yes       | Yes         |
-| [PearAI](https://trypear.ai)             | [Maker](https://trypear.ai/pricing) (15 \$/m)   | Tokens       | No     | Yes       | Yes         |
-| [Windsurf](https://windsurf.com)         | [Pro](https://windsurf.com/pricing) (15 \$/m)   | Subscription | No     | Yes       | No          |
-| [Cursor](https://www.cursor.com)         | [Pro](https://www.cursor.com/pricing) (20 \$/m) | Subscription | 2-week | Yes       | No          |
-| [Aide](https://aide.dev)                 | [Creator](https://aide.dev/pricing) (20 \$/m)   | Subscription | No     | Yes       | Yes         |
-| [Kiro](https://kiro.dev)                 | [Kiro Pro](https://kiro.dev/pricing) (20 \$/m)  | Subscription | 2-week | Yes       | No          |
-| [Qoder][qoder-ref]                       | Pro (20 \$/m)                                   | Subscription | Beta   | Beta      | No          |
-| [BuilderStudio](https://builderstudio.dev) | BYOK                                          | Tokens       | 7-days | Yes       | No          |
+| Name                                       | Minimal plan                                    | Usage        | Trial  | Free plan | Open Source |
+| ------------------------------------------ | ----------------------------------------------- | ------------ | ------ | --------- | ----------- |
+| [BuilderStudio](https://builderstudio.dev) | BYOK                                            | Tokens       | 7-days | Yes       | No          |
+| [FlexPilot AI](https://flexpilot.ai)       | BYOK                                            | Tokens       | -      | -         | Yes         |
+| [humanlayer](https://www.humanlayer.dev)   | BYOK                                            | Tokens       | -      | -         | Yes         |
+| [VoidEditor](https://voideditor.com)       | BYOK                                            | Tokens       | -      | -         | Yes         |
+| [Trae AI](https://trae.ai)                 | [Pro](https://www.trae.ai/pricing) (10 \$/m)    | Subscription | 3 \$/m | Yes       | No          |
+| [Zed](https://zed.dev)                     | [Pro](https://zed.dev/pricing) (10 \$/m)        | Tokens       | 2-week | Yes       | Yes         |
+| [PearAI](https://trypear.ai)               | [Maker](https://trypear.ai/pricing) (15 \$/m)   | Tokens       | No     | Yes       | Yes         |
+| [Windsurf](https://windsurf.com)           | [Pro](https://windsurf.com/pricing) (15 \$/m)   | Subscription | No     | Yes       | No          |
+| [Cursor](https://www.cursor.com)           | [Pro](https://www.cursor.com/pricing) (20 \$/m) | Subscription | 2-week | Yes       | No          |
+| [Aide](https://aide.dev)                   | [Creator](https://aide.dev/pricing) (20 \$/m)   | Subscription | No     | Yes       | Yes         |
+| [Kiro](https://kiro.dev)                   | [Kiro Pro](https://kiro.dev/pricing) (20 \$/m)  | Subscription | 2-week | Yes       | No          |
+| [Qoder][qoder-ref]                         | Pro (20 \$/m)                                   | Subscription | Beta   | Beta      | No          |
 
 ## Extensions
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ List of AI-powered IDEs and code editors.
 | [Kiro](https://kiro.dev)                   | [Kiro Pro](https://kiro.dev/pricing) (20 \$/m)  | Subscription | 2-week | Yes       | No          |
 | [Qoder][qoder-ref]                         | Pro (20 \$/m)                                   | Subscription | Beta   | Beta      | No          |
 
+---
+
 ## Extensions
 
 List of AI-powered coding plugins and extensions. See [feature matrix](./FEATURE_MATRIX.md#extensions).

--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ List of AI-powered command-line tools. See [feature matrix](./FEATURE_MATRIX.md#
 
 ## Tools
 
-
 | Name           | Link                                        |
 | -------------- | ------------------------------------------- |
 | agenttrace     | <https://github.com/luoyuctl/agenttrace>    |

--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ List of AI-powered IDEs and code editors.
 | [Aide](https://aide.dev)                 | [Creator](https://aide.dev/pricing) (20 \$/m)   | Subscription | No     | Yes       | Yes         |
 | [Kiro](https://kiro.dev)                 | [Kiro Pro](https://kiro.dev/pricing) (20 \$/m)  | Subscription | 2-week | Yes       | No          |
 | [Qoder][qoder-ref]                       | Pro (20 \$/m)                                   | Subscription | Beta   | Beta      | No          |
-
----
+| [BuilderStudio](https://builderstudio.dev) | BYOK                                          | Tokens       | 7-days | Yes       | No          |
 
 ## Extensions
 
@@ -170,8 +169,6 @@ List of AI-powered command-line tools. See [feature matrix](./FEATURE_MATRIX.md#
 ---
 
 ## Tools
-
-* [BuilderStudio](https://builderstudio.dev) - Native macOS agentic coding workspace from WunderCorp for secure local/cloud AI development, reusable Skills and Pathways, MCP integrations, Hermes-powered container-only execution, Agentic Swarms for parallel specialized agents, app previews, terminal workflows, packaging/deployment, and flexible routing across 380+ AI models.
 
 
 | Name           | Link                                        |

--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ List of AI-powered command-line tools. See [feature matrix](./FEATURE_MATRIX.md#
 
 ## Tools
 
+* [BuilderStudio](https://builderstudio.dev) - Native macOS agentic coding workspace from WunderCorp for secure local/cloud AI development, reusable Skills and Pathways, MCP integrations, Hermes-powered container-only execution, Agentic Swarms for parallel specialized agents, app previews, terminal workflows, packaging/deployment, and flexible routing across 380+ AI models.
+
+
 | Name           | Link                                        |
 | -------------- | ------------------------------------------- |
 | agenttrace     | <https://github.com/luoyuctl/agenttrace>    |


### PR DESCRIPTION
## Description

Adds BuilderStudio by WunderCorp to this curated list.

BuilderStudio is a native macOS agentic coding workspace for builders and teams that want to create software locally and securely without being locked into a single AI provider. It combines AI coding agents, reusable Skills, guided Pathways, MCP integrations, local/cloud execution, terminal workflows, app previews, packaging/deployment support, Hermes-powered contained execution, Agentic Swarms for parallel specialized agents, and flexible routing across 380+ AI models.

## Why it fits

- Native macOS workspace for local-first agentic development.
- Hermes-powered contained execution for safer local agent runs.
- Agentic Swarms for running multiple specialized Hermes lanes in parallel through Colima/Docker.
- Reusable Skills and guided Pathways for repeatable AI development workflows.
- MCP integrations, workflow creator UI, app previews, source editing, terminal workflows, packaging, and deployment support.
- Flexible routing across 380+ AI models instead of locking teams into one provider.

## Verification

This is a Markdown/list-entry-only contribution. I checked that the entry uses public BuilderStudio links and follows the target repository's existing curated-list style as closely as possible.

## Checklist

- [x] This PR is a Markdown/list-entry-only BuilderStudio submission.
- [x] The entry uses public links for BuilderStudio and BuilderStudio Skills.

## Links

- Website: https://builderstudio.dev
- Skills catalog: https://github.com/wundercorp/builderstudio-skills
- WunderCorp on X: https://x.com/wundercorp

## Links

- Website: https://builderstudio.dev
- Skills catalog: https://github.com/wundercorp/builderstudio-skills
- WunderCorp on X: https://x.com/wundercorp
