### PR TITLE
Add ax to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ List of AI-powered command-line tools. See [feature matrix](./FEATURE_MATRIX.md#
 | Name           | Link                                        |
 | -------------- | ------------------------------------------- |
 | agenttrace     | <https://github.com/luoyuctl/agenttrace>    |
+| ax             | <https://github.com/Necmttn/ax>             |
 | codex-profiles | <https://github.com/Ducksss/codex-profiles> |
 
 ---


### PR DESCRIPTION
Adds ax to the small Tools table alongside adjacent utilities like agenttrace and codex-profiles. ax fits there as local telemetry and recall infrastructure for AI coding-agent sessions.

Checks:
- git diff --check
- verified https://github.com/Necmttn/ax returns 200
- markdownlint README.md remains at the existing 15-error baseline

---

_Generated with [ax](https://github.com/Necmttn/ax)._