### PR TITLE
Add VibeKit.bot to SaaS / Web-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ List of AI-powered cloud-based developer tools.
 | [Lovable](https://lovable.dev)              | [Pro](https://lovable.dev/pricing) (25 \$/m)             | No            | Yes       | No          | Frontend   |
 | [Bolt.new](https://bolt.new)                | [Pro](https://bolt.new/pricing) (25 \$/m)                | No            | Yes       | No          | Full-stack |
 | [Builder](https://builder.io)               | [Pro](https://www.builder.io/m/pricing) (30 \$/m)        | No            | Yes       | No          | Frontend   |
+| [VibeKit.bot](https://vibekit.bot)          | Pay-as-you-go (credits)                                  | Free tier     | Yes       | No          | Full-stack |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ List of AI-powered cloud-based developer tools.
 | [Lovable](https://lovable.dev)              | [Pro](https://lovable.dev/pricing) (25 \$/m)             | No            | Yes       | No          | Frontend   |
 | [Bolt.new](https://bolt.new)                | [Pro](https://bolt.new/pricing) (25 \$/m)                | No            | Yes       | No          | Full-stack |
 | [Builder](https://builder.io)               | [Pro](https://www.builder.io/m/pricing) (30 \$/m)        | No            | Yes       | No          | Frontend   |
-| [VibeKit.bot](https://vibekit.bot)          | Pay-as-you-go (credits)                                  | Free tier     | Yes       | No          | Full-stack |
+| [VibeKit.bot](https://vibekit.bot)          | Pay-as-you-Go                                            | No            | Yes       | No          | Full-stack |
 
 ---
 


### PR DESCRIPTION
Adds **VibeKit.bot** to *SaaS / Web-app*.

Every app gets its own **persistent** AI coding agent that builds it, hosts it at a live domain, and keeps improving it with each message. It runs from a phone (native iOS app) or the web, so it covers building and iterating without a laptop.

Free tier, bring-your-own-key (Claude/OpenAI), or pay-as-you-go.

(Disambiguation: we are "VibeKit.bot", the hosted app builder; an unrelated discontinued npm SDK shares the name "vibekit".)