### PR TITLE
docs: add Standard Compute to provider subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Donations to project with credits on LLM/AI inferences or such bonuses from prov
 | [GLM Coding][z-ai-ref]                                    | [Lite][z-ai-ref] (18 \$/m)                                                                                  | -            | =< 120 prompts / 5-hr |
 | [Kilo Pass](https://kilo.ai/features/kilo-pass)           | [Starter](https://kilo.ai/features/kilo-pass)(19 \$/m)                                                      | 50% bonus    | Tokens                |
 | [Kimi Coding](https://www.kimi.com)                       | [Moderato](https://www.kimi.com/membership/pricing) (19 \$/m)                                               | -            | -                     |
+| [Standard Compute](https://standardcompute.com) | [Starter](https://standardcompute.com/pricing) (19 \$/m) | Free trial | $20 monthly compute budget; pauses at exhaustion |
 | [Claude Code](https://claude.com)                         | [Pro](https://claude.com/pricing) (20 \$/m)                                                                 | -            | <= 30 prompts / 5-hr  |
 | [ChatGPT Codex](https://chatgpt.com)                      | [Plus](https://chatgpt.com/pricing) (20 \$/m)                                                               | -            | <= 100 prompts / 5-hr |
 | [Google AI](https://one.google.com/about/google-ai-plans) | [Pro](https://one.google.com/about/google-ai-plans) (20 \$/m)                                               | Free plan    | <= 100 prompts / 5-hr |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Donations to project with credits on LLM/AI inferences or such bonuses from prov
 | [GLM Coding][z-ai-ref]                                    | [Lite][z-ai-ref] (18 \$/m)                                                                                  | -            | =< 120 prompts / 5-hr |
 | [Kilo Pass](https://kilo.ai/features/kilo-pass)           | [Starter](https://kilo.ai/features/kilo-pass)(19 \$/m)                                                      | 50% bonus    | Tokens                |
 | [Kimi Coding](https://www.kimi.com)                       | [Moderato](https://www.kimi.com/membership/pricing) (19 \$/m)                                               | -            | -                     |
-| [Standard Compute](https://standardcompute.com) | [Starter](https://standardcompute.com/pricing) (19 \$/m) | Free trial | $20 monthly compute budget; pauses at exhaustion |
+| [Standard Compute](https://standardcompute.com)           | [Starter](https://standardcompute.com/pricing) (19 \$/m)                                                    |  ?           | $20 value             |
 | [Claude Code](https://claude.com)                         | [Pro](https://claude.com/pricing) (20 \$/m)                                                                 | -            | <= 30 prompts / 5-hr  |
 | [ChatGPT Codex](https://chatgpt.com)                      | [Plus](https://chatgpt.com/pricing) (20 \$/m)                                                               | -            | <= 100 prompts / 5-hr |
 | [Google AI](https://one.google.com/about/google-ai-plans) | [Pro](https://one.google.com/about/google-ai-plans) (20 \$/m)                                               | Free plan    | <= 100 prompts / 5-hr |


### PR DESCRIPTION
Adds Standard Compute under Providers → Subscriptions, alongside the other $19 plans and before $20 plans. Starter is $19/month with $20 of monthly compute budget; requests pause when that budget is exhausted. The pricing page offers a free trial, without a fixed trial allowance asserted here.

Source checked September 5, 2026: [official pricing, comparison table and trial FAQ](https://standardcompute.com/pricing).

Read CONTRIBUTING.md and CODE_OF_CONDUCT.md; checked existing PRs for duplicates, the four-column table and price order. No author-verification badge or sponsor status is added.

Disclosure: I run Standard Compute. This contribution was prepared with AI assistance.